### PR TITLE
feat: add support for karpenter metrics in datadog

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -102,7 +102,12 @@ variable "metrics_enabled" {
 variable "metrics_port" {
   type        = number
   description = "Container port to use for metrics"
-  default     = 8000
+  default     = 8080
+
+  validation {
+    condition     = var.metrics_port > 0 && var.metrics_port < 65536
+    error_message = "The metrics port must be between 1 and 65535."
+  }
 }
 
 variable "interruption_handler_enabled" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -93,6 +93,18 @@ variable "eks_component_name" {
   default     = "eks/cluster"
 }
 
+variable "metrics_enabled" {
+  type        = bool
+  description = "Whether to expose the Karpenter's Prometheus metric"
+  default     = true
+}
+
+variable "metrics_port" {
+  type        = number
+  description = "Container port to use for metrics"
+  default     = 8000
+}
+
 variable "interruption_handler_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what

> [!TIP]
> Feel free to accept, disregard, or close this addition. We are using it in our environment as it has provided actionable information for us

- Incorporates toggle for enabling the metrics port and annotations for exposing Karpenter metrics to the Datadog agent
- This check uses [OpenMetrics](https://docs.datadoghq.com/integrations/openmetrics/) to collect metrics from the OpenMetrics endpoint that Karpenter exposes, which requires Python 3.

## why

![dashboard](https://github.com/user-attachments/assets/90d4c1f4-19ea-43fa-b2bc-78db583dd833)

- Adds support for monitoring the health and performance of Karpenter
- Makes metrics accessible in the Datadog Karpenter Overview Dashboard

> [!NOTE]
> The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.

## references

- [Karpenter Metrics](https://karpenter.sh/docs/reference/metrics/)
- [Datadog Integration](https://app.datadoghq.com/integrations/karpenter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configurable metrics and monitoring options for Karpenter deployment.
	- Introduced new variables to control metrics exposure and port configuration.
	- Enhanced Karpenter deployment with Datadog monitoring capabilities.

- **Configuration**
	- Added support for dynamic replica count configuration.
	- Implemented optional metrics and logging settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->