### PR TITLE
helm v3

### DIFF
--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -172,7 +172,7 @@ provider "helm" {
       }
     }
   }
-  experiments {
+  experiments = {
     manifest = var.helm_manifest_experiment_enabled && module.this.enabled
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## what
* Helm provider needs to be pinned to v2 or support v3 syntax for experiments

## references
* https://registry.terraform.io/providers/hashicorp/helm/latest/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Helm provider version requirement to 3.0 or higher.
  - Adjusted provider configuration syntax for improved compatibility with newer Terraform standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->