### PR TITLE
Add feature gates to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ components:
         # https://github.com/aws/karpenter/tree/main/charts/karpenter
         chart_repository: "oci://public.ecr.aws/karpenter"
         chart: "karpenter"
-        chart_version: "v0.36.0"
+        chart_version: "0.36.0"
         # Enable Karpenter to get advance notice of spot instances being terminated
         # See https://karpenter.sh/docs/concepts/#interruption
         interruption_handler_enabled: true

--- a/README.yaml
+++ b/README.yaml
@@ -28,7 +28,7 @@ description: |-
           # https://github.com/aws/karpenter/tree/main/charts/karpenter
           chart_repository: "oci://public.ecr.aws/karpenter"
           chart: "karpenter"
-          chart_version: "v0.36.0"
+          chart_version: "v1.6.0"
           # Enable Karpenter to get advance notice of spot instances being terminated
           # See https://karpenter.sh/docs/concepts/#interruption
           interruption_handler_enabled: true
@@ -42,7 +42,6 @@ description: |-
           cleanup_on_fail: true
           atomic: true
           wait: true
-          rbac_enabled: true
           # "karpenter-crd" can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs
           crd_chart_enabled: true
           crd_chart: "karpenter-crd"
@@ -53,6 +52,12 @@ description: |-
           settings:
             batch_idle_duration: "1s"
             batch_max_duration: "10s"
+          # (Optional) "settings" which do not have an explicit mapping and may be subject to change between helm chart versions
+          additional_settings:
+            featureGates:
+              nodeRepair: false
+              reservedCapacity: true
+              spotToSpotConsolidation: true
           # The logging settings for the Karpenter controller
           logging:
             enabled: true

--- a/README.yaml
+++ b/README.yaml
@@ -28,7 +28,7 @@ description: |-
           # https://github.com/aws/karpenter/tree/main/charts/karpenter
           chart_repository: "oci://public.ecr.aws/karpenter"
           chart: "karpenter"
-          chart_version: "v1.6.0"
+          chart_version: "1.6.0"
           # Enable Karpenter to get advance notice of spot instances being terminated
           # See https://karpenter.sh/docs/concepts/#interruption
           interruption_handler_enabled: true

--- a/src/README.md
+++ b/src/README.md
@@ -57,7 +57,11 @@ components:
         settings:
           batch_idle_duration: "1s"
           batch_max_duration: "10s"
-          feature_gates:
+        # (Optional) "settings" which do not have an explicit mapping and may be subject to change between helm chart versions
+        extra_settings:
+          featureGates:
+            node_repair: false
+            reserved_capacity: true
             spot_to_spot_consolidation: true
         # The logging settings for the Karpenter controller
         logging:

--- a/src/README.md
+++ b/src/README.md
@@ -33,7 +33,7 @@ components:
         # https://github.com/aws/karpenter/tree/main/charts/karpenter
         chart_repository: "oci://public.ecr.aws/karpenter"
         chart: "karpenter"
-        chart_version: "v1.6.0"
+        chart_version: "1.6.0"
         # Enable Karpenter to get advance notice of spot instances being terminated
         # See https://karpenter.sh/docs/concepts/#interruption
         interruption_handler_enabled: true

--- a/src/README.md
+++ b/src/README.md
@@ -33,7 +33,7 @@ components:
         # https://github.com/aws/karpenter/tree/main/charts/karpenter
         chart_repository: "oci://public.ecr.aws/karpenter"
         chart: "karpenter"
-        chart_version: "v0.36.0"
+        chart_version: "v1.6.0"
         # Enable Karpenter to get advance notice of spot instances being terminated
         # See https://karpenter.sh/docs/concepts/#interruption
         interruption_handler_enabled: true
@@ -47,7 +47,6 @@ components:
         cleanup_on_fail: true
         atomic: true
         wait: true
-        rbac_enabled: true
         # "karpenter-crd" can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs
         crd_chart_enabled: true
         crd_chart: "karpenter-crd"
@@ -58,6 +57,8 @@ components:
         settings:
           batch_idle_duration: "1s"
           batch_max_duration: "10s"
+          feature_gates:
+            spot_to_spot_consolidation: true
         # The logging settings for the Karpenter controller
         logging:
           enabled: true

--- a/src/README.md
+++ b/src/README.md
@@ -58,11 +58,11 @@ components:
           batch_idle_duration: "1s"
           batch_max_duration: "10s"
         # (Optional) "settings" which do not have an explicit mapping and may be subject to change between helm chart versions
-        extra_settings:
+        additional_settings:
           featureGates:
-            node_repair: false
-            reserved_capacity: true
-            spot_to_spot_consolidation: true
+            nodeRepair: false
+            reservedCapacity: true
+            spotToSpotConsolidation: true
         # The logging settings for the Karpenter controller
         logging:
           enabled: true

--- a/src/main.tf
+++ b/src/main.tf
@@ -119,12 +119,13 @@ module "karpenter" {
           webhook    = var.logging.level.webhook
         }
       }
-      settings = merge({
+      settings = merge(
+        var.additional_settings,
+        {
         batchIdleDuration = var.settings.batch_idle_duration
         batchMaxDuration  = var.settings.batch_max_duration
         clusterName       = local.eks_cluster_id
         },
-        var.additional_settings,
         local.interruption_handler_enabled ? {
           interruptionQueue = local.interruption_handler_queue_name
         } : {}

--- a/src/main.tf
+++ b/src/main.tf
@@ -123,12 +123,8 @@ module "karpenter" {
         batchIdleDuration = var.settings.batch_idle_duration
         batchMaxDuration  = var.settings.batch_max_duration
         clusterName       = local.eks_cluster_id
-        featureGates = {
-          nodeRepair = coalesce(var.settings.feature_gates.node_repair, false)
-          reservedCapacity = coalesce(var.settings.feature_gates.reserved_capacity, true)
-          spotToSpotConsolidation = coalesce(var.settings.feature_gates.spot_to_spot_consolidation, false)
-        }
         },
+        var.extra_settings,
         local.interruption_handler_enabled ? {
           interruptionQueue = local.interruption_handler_queue_name
         } : {}

--- a/src/main.tf
+++ b/src/main.tf
@@ -122,9 +122,9 @@ module "karpenter" {
       settings = merge(
         var.additional_settings,
         {
-        batchIdleDuration = var.settings.batch_idle_duration
-        batchMaxDuration  = var.settings.batch_max_duration
-        clusterName       = local.eks_cluster_id
+          batchIdleDuration = var.settings.batch_idle_duration
+          batchMaxDuration  = var.settings.batch_max_duration
+          clusterName       = local.eks_cluster_id
         },
         local.interruption_handler_enabled ? {
           interruptionQueue = local.interruption_handler_queue_name

--- a/src/main.tf
+++ b/src/main.tf
@@ -123,6 +123,11 @@ module "karpenter" {
         batchIdleDuration = var.settings.batch_idle_duration
         batchMaxDuration  = var.settings.batch_max_duration
         clusterName       = local.eks_cluster_id
+        featureGates = {
+          nodeRepair = coalesce(var.settings.feature_gates.node_repair, false)
+          reservedCapacity = coalesce(var.settings.feature_gates.reserved_capacity, true)
+          spotToSpotConsolidation = coalesce(var.settings.feature_gates.spot_to_spot_consolidation, false)
+        }
         },
         local.interruption_handler_enabled ? {
           interruptionQueue = local.interruption_handler_queue_name

--- a/src/main.tf
+++ b/src/main.tf
@@ -124,7 +124,7 @@ module "karpenter" {
         batchMaxDuration  = var.settings.batch_max_duration
         clusterName       = local.eks_cluster_id
         },
-        var.extra_settings,
+        var.additional_settings,
         local.interruption_handler_enabled ? {
           interruptionQueue = local.interruption_handler_queue_name
         } : {}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -141,7 +141,7 @@ variable "settings" {
   nullable    = false
 }
 
-variable "extra_settings" {
+variable "additional_settings" {
   type        = any
   description = <<-EOT
   Additional settings to merge into the Karpenter controller settings.
@@ -150,7 +150,7 @@ variable "extra_settings" {
   and take precedence over any conflicting keys.
   
   Example:
-  extra_settings = {
+  additional_settings = {
     featureGates = {
       nodeRepair = false
       reservedCapacity = true

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -129,6 +129,11 @@ variable "settings" {
   type = object({
     batch_idle_duration = optional(string, "1s")
     batch_max_duration  = optional(string, "10s")
+    feature_gates = object({
+      node_repair = optional(bool, false)
+      reserved_capacity = optional(bool, true)
+      spot_to_spot_consolidation = optional(bool, false)
+    })
   })
   description = <<-EOT
   A subset of the settings for the Karpenter controller.

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -129,11 +129,6 @@ variable "settings" {
   type = object({
     batch_idle_duration = optional(string, "1s")
     batch_max_duration  = optional(string, "10s")
-    feature_gates = object({
-      node_repair = optional(bool, false)
-      reserved_capacity = optional(bool, true)
-      spot_to_spot_consolidation = optional(bool, false)
-    })
   })
   description = <<-EOT
   A subset of the settings for the Karpenter controller.
@@ -141,6 +136,27 @@ variable "settings" {
   `interruptionQueue`. All settings can be overridden by providing a `settings`
   section in the `chart_values` variable. The settings provided here are the ones
   mostly likely to be set to other than default values, and are provided here for convenience.
+  EOT
+  default     = {}
+  nullable    = false
+}
+
+variable "extra_settings" {
+  type        = any
+  description = <<-EOT
+  Additional settings to merge into the Karpenter controller settings.
+  This is useful for setting featureGates or other advanced settings that may
+  vary by chart version. These settings will be merged with the base settings
+  and take precedence over any conflicting keys.
+  
+  Example:
+  extra_settings = {
+    featureGates = {
+      nodeRepair = false
+      reservedCapacity = true
+      spotToSpotConsolidation = false
+    }
+  }
   EOT
   default     = {}
   nullable    = false

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -24,7 +24,6 @@ components:
         cleanup_on_fail: true
         atomic: true
         wait: true
-        rbac_enabled: true
         # "karpenter-crd" can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs
         crd_chart_enabled: true
         crd_chart: "karpenter-crd"

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -10,7 +10,7 @@ components:
         # https://github.com/aws/karpenter/tree/main/charts/karpenter
         chart_repository: "oci://public.ecr.aws/karpenter"
         chart: "karpenter"
-        chart_version: "v0.36.0"
+        chart_version: "0.36.0"
         # Enable Karpenter to get advance notice of spot instances being terminated
         # See https://karpenter.sh/docs/concepts/#interruption
         interruption_handler_enabled: true

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -24,7 +24,6 @@ components:
         cleanup_on_fail: true
         atomic: true
         wait: true
-        rbac_enabled: true
         # "karpenter-crd" can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs
         crd_chart_enabled: true
         crd_chart: "karpenter-crd"

--- a/test/fixtures/stacks/catalog/usecase/featureGates.yaml
+++ b/test/fixtures/stacks/catalog/usecase/featureGates.yaml
@@ -34,7 +34,7 @@ components:
         settings:
           batch_idle_duration: "1s"
           batch_max_duration: "10s"
-        # "extra_settings" allows for chart version-specific settings like featureGates
+        # "additional_settings" allows for chart version-specific settings like featureGates
         additional_settings:
           featureGates:
             nodeRepair: false

--- a/test/fixtures/stacks/catalog/usecase/featureGates.yaml
+++ b/test/fixtures/stacks/catalog/usecase/featureGates.yaml
@@ -35,11 +35,11 @@ components:
           batch_idle_duration: "1s"
           batch_max_duration: "10s"
         # "extra_settings" allows for chart version-specific settings like featureGates
-        extra_settings:
+        additional_settings:
           featureGates:
-            node_repair: false
-            reserved_capacity: true
-            spot_to_spot_consolidation: true
+            nodeRepair: false
+            reservedCapacity: true
+            spotToSpotConsolidation: true
         # The logging settings for the Karpenter controller
         logging:
           enabled: true

--- a/test/fixtures/stacks/catalog/usecase/featureGates.yaml
+++ b/test/fixtures/stacks/catalog/usecase/featureGates.yaml
@@ -1,0 +1,49 @@
+components:
+  terraform:
+    eks/karpenter-controller/basic:
+      metadata:
+        component: eks/karpenter-controller
+      vars:
+        enabled: true
+        kube_exec_auth_role_arn_enabled: false
+        name: "karpenter"
+        # https://github.com/aws/karpenter/tree/main/charts/karpenter
+        chart_repository: "oci://public.ecr.aws/karpenter"
+        chart: "karpenter"
+        chart_version: "1.6.0"
+        # Enable Karpenter to get advance notice of spot instances being terminated
+        # See https://karpenter.sh/docs/concepts/#interruption
+        interruption_handler_enabled: true
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "512Mi"
+        cleanup_on_fail: true
+        atomic: true
+        wait: true
+        # "karpenter-crd" can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs
+        crd_chart_enabled: true
+        crd_chart: "karpenter-crd"
+        # replicas set the number of Karpenter controller replicas to run
+        replicas: 2
+        # "settings" controls a subset of the settings for the Karpenter controller regarding batch idle and max duration.
+        # you can read more about these settings here: https://karpenter.sh/docs/reference/settings/
+        settings:
+          batch_idle_duration: "1s"
+          batch_max_duration: "10s"
+        # "extra_settings" allows for chart version-specific settings like featureGates
+        extra_settings:
+          featureGates:
+            node_repair: false
+            reserved_capacity: true
+            spot_to_spot_consolidation: true
+        # The logging settings for the Karpenter controller
+        logging:
+          enabled: true
+          level:
+            controller: "info"
+            global: "info"
+            webhook: "error"


### PR DESCRIPTION
## what
* Added `additional_settings` attribute to enable setting featurGates and other similar configurations not explicitly supported
* Removed `rbac_enabled` from tests and example since it does not exist as a var
* Added test case for usage of the additional_settings
* Updated the example in the README.md

## why
* FeatureGates is a powerful setting to support but may change often. To avoid maintaining a compatibility matrix the capability has been added as `additional_settings` also allowing for support of other configurations customers may want


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added additional_settings to allow merging advanced Karpenter settings, including optional featureGates (nodeRepair, reservedCapacity, spotToSpotConsolidation).
- Chores
  - Updated Karpenter chart version to 1.6.0.
  - Removed explicit RBAC override from examples (now rely on default behavior).
- Documentation
  - README examples updated for chart version and featureGates usage.
- Tests
  - Added featureGates fixture and updated fixtures to remove deprecated RBAC flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->