### PR TITLE
feat: add account_map_enabled and eks object variable for direct EKS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,133 @@ To deploy the `karpenter-crd` helm chart, set `var.crd_chart_enabled` to `true`.
 is recommended. `var.crd_chart_enabled` defaults to `false` to preserve backward compatibility with older versions of
 this component.)
 
+## Using Direct EKS Cluster Variables (Recommended)
+
+This component supports two methods for obtaining EKS cluster information, controlled by the
+`remote_state_enabled` variable:
+
+1. **Direct Variables (Recommended)**: Set `remote_state_enabled: false` and pass EKS cluster details directly via input variables
+2. **Remote State (Default, Deprecated)**: Set `remote_state_enabled: true` (default) to fetch EKS cluster details from Terraform remote state using `eks_component_name`
+
+### Direct Variables Approach
+
+The recommended approach is to provide EKS cluster information directly by setting `remote_state_enabled: false`.
+This removes the dependency on Cloud Posse's remote state module and gives you more flexibility in how you
+manage your infrastructure.
+
+Required variables when `remote_state_enabled` is `false`:
+- `eks_cluster_id` - The EKS cluster ID (name)
+- `eks_cluster_arn` - The EKS cluster ARN
+- `eks_cluster_endpoint` - The EKS cluster API endpoint URL
+- `eks_cluster_certificate_authority_data` - The base64 encoded certificate data
+- `eks_cluster_identity_oidc_issuer` - The OIDC Identity issuer for the EKS cluster
+- `karpenter_node_role_arn` - The ARN of the IAM role for Karpenter nodes
+
+Example configuration using direct variables:
+
+```yaml
+components:
+  terraform:
+    eks/karpenter:
+      vars:
+        enabled: true
+        name: "karpenter"
+        # Disable remote state and use direct EKS cluster configuration
+        remote_state_enabled: false
+        eks_cluster_id: "my-eks-cluster"
+        eks_cluster_arn: "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster"
+        eks_cluster_endpoint: "https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com"
+        eks_cluster_certificate_authority_data: "LS0tLS1CRUdJTi..."
+        eks_cluster_identity_oidc_issuer: "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
+        karpenter_node_role_arn: "arn:aws:iam::123456789012:role/my-eks-cluster-karpenter-node"
+        # ... other karpenter configuration
+        chart_repository: "oci://public.ecr.aws/karpenter"
+        chart: "karpenter"
+        chart_version: "1.6.0"
+```
+
+You can obtain these values from your EKS cluster's Terraform outputs or via AWS CLI:
+
+```bash
+# Get cluster info
+aws eks describe-cluster --name my-eks-cluster --query 'cluster.{
+  endpoint: endpoint,
+  arn: arn,
+  certificateAuthority: certificateAuthority.data,
+  oidcIssuer: identity.oidc.issuer
+}'
+```
+
+### Migrating from Remote State
+
+If you're currently using the default `remote_state_enabled: true` with `eks_component_name` to fetch
+EKS cluster information from remote state, you can migrate to direct variables by:
+
+1. Get the current values from your EKS cluster's Terraform state or AWS console
+2. Set `remote_state_enabled: false` in your stack configuration
+3. Add the direct variable values to your stack configuration
+
+> [!NOTE]
+> When `remote_state_enabled` is `false`, all six direct EKS cluster variables are required.
+> Terraform will fail validation if any are missing.
+
+### Using Atmos State Functions (Recommended)
+
+When using [Atmos](https://atmos.tools), you can use the `!terraform.state` function to read
+EKS cluster outputs from another component's Terraform state and pass them as variables.
+This is the recommended approach as it keeps state lookups in your stack configuration
+rather than in Terraform code.
+
+```yaml
+components:
+  terraform:
+    eks/karpenter:
+      vars:
+        enabled: true
+        name: "karpenter"
+        # Disable internal remote state lookup
+        remote_state_enabled: false
+        # Use Atmos !terraform.state to read values from eks/cluster component
+        eks_cluster_id: !terraform.state eks/cluster eks_cluster_id
+        eks_cluster_arn: !terraform.state eks/cluster eks_cluster_arn
+        eks_cluster_endpoint: !terraform.state eks/cluster eks_cluster_endpoint
+        eks_cluster_certificate_authority_data: !terraform.state eks/cluster eks_cluster_certificate_authority_data
+        eks_cluster_identity_oidc_issuer: !terraform.state eks/cluster eks_cluster_identity_oidc_issuer
+        karpenter_node_role_arn: !terraform.state eks/cluster karpenter_iam_role_arn
+        # ... other karpenter configuration
+        chart_repository: "oci://public.ecr.aws/karpenter"
+        chart: "karpenter"
+        chart_version: "1.6.0"
+```
+
+This approach:
+- Keeps Terraform code clean without internal remote state dependencies
+- Uses Atmos native state functions for cross-component references
+- Works seamlessly with Atmos stack inheritance and overrides
+- Provides better visibility into component dependencies in stack configuration
+
+For more information on `!terraform.state`, see the
+[Atmos documentation](https://atmos.tools/core-concepts/stacks/templating/functions/terraform.state/).
+
+### Remote State Approach (Default, Deprecated)
+
+> [!WARNING]
+> The `remote_state_enabled: true` setting and `eks_component_name` variable are deprecated and will
+> be removed in a future version. Please migrate to using direct EKS cluster variables.
+
+The default (but deprecated) approach uses Cloud Posse's remote state module to fetch EKS cluster information:
+
+```yaml
+components:
+  terraform:
+    eks/karpenter:
+      vars:
+        enabled: true
+        # remote_state_enabled defaults to true (deprecated)
+        eks_component_name: "eks/cluster-blue"
+        # ... other configuration
+```
+
 ## Troubleshooting
 
 For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://karpenter.sh/docs/troubleshooting/)
@@ -395,6 +522,7 @@ For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://kar
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -416,6 +544,7 @@ For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://kar
 | [aws_iam_role_policy_attachment.v1alpha](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_sqs_queue.interruption_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.interruption_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
+| [terraform_data.validate_eks_config](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_iam_policy_document.interruption_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -439,13 +568,19 @@ For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://kar
 | <a name="input_crd_chart_enabled"></a> [crd\_chart\_enabled](#input\_crd\_chart\_enabled) | `karpenter-crd` can be installed as an independent helm chart to manage the lifecycle of Karpenter CRDs. Set to `true` to install this CRD helm chart before the primary karpenter chart. | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>  format = string<br/>  labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
+| <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | The EKS cluster ARN. Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
+| <a name="input_eks_cluster_certificate_authority_data"></a> [eks\_cluster\_certificate\_authority\_data](#input\_eks\_cluster\_certificate\_authority\_data) | The base64 encoded certificate data required to communicate with the EKS cluster. Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
+| <a name="input_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#input\_eks\_cluster\_endpoint) | The EKS cluster endpoint URL. Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
+| <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | The EKS cluster ID (name). Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
+| <a name="input_eks_cluster_identity_oidc_issuer"></a> [eks\_cluster\_identity\_oidc\_issuer](#input\_eks\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the EKS cluster. Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
+| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component. Used to fetch EKS cluster information from remote state<br/>when `remote_state_enabled` is `true`.<br/><br/>DEPRECATED: This variable (along with remote\_state\_enabled=true) is deprecated and<br/>will be removed in a future version. Set `remote_state_enabled = false` and use<br/>the direct EKS cluster input variables instead. | `string` | `"eks/cluster"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_interruption_handler_enabled"></a> [interruption\_handler\_enabled](#input\_interruption\_handler\_enabled) | If `true`, deploy a SQS queue and Event Bridge rules to enable interruption handling by Karpenter.<br/>  https://karpenter.sh/docs/concepts/disruption/#interruption | `bool` | `true` | no |
 | <a name="input_interruption_queue_message_retention"></a> [interruption\_queue\_message\_retention](#input\_interruption\_queue\_message\_retention) | The message retention in seconds for the interruption handler SQS queue. | `number` | `300` | no |
+| <a name="input_karpenter_node_role_arn"></a> [karpenter\_node\_role\_arn](#input\_karpenter\_node\_role\_arn) | The ARN of the IAM role for Karpenter nodes. Required when `remote_state_enabled` is `false`. | `string` | `null` | no |
 | <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br/>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
 | <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
 | <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
@@ -468,6 +603,7 @@ For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://kar
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_remote_state_enabled"></a> [remote\_state\_enabled](#input\_remote\_state\_enabled) | If `true`, fetch EKS cluster information from Terraform remote state using `eks_component_name`.<br/>If `false`, use direct EKS cluster input variables instead.<br/><br/>When set to `false`, the following variables are required:<br/>- var.eks\_cluster\_id<br/>- var.eks\_cluster\_arn<br/>- var.eks\_cluster\_endpoint<br/>- var.eks\_cluster\_certificate\_authority\_data<br/>- var.eks\_cluster\_identity\_oidc\_issuer<br/>- var.karpenter\_node\_role\_arn | `bool` | `true` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of Karpenter controller replicas to run | `number` | `2` | no |
 | <a name="input_resources"></a> [resources](#input\_resources) | The CPU and memory of the deployment's limits and requests | <pre>object({<br/>    limits = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>    requests = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_settings"></a> [settings](#input\_settings) | A subset of the settings for the Karpenter controller.<br/>Some settings are implicitly set by this component, such as `clusterName` and<br/>`interruptionQueue`. All settings can be overridden by providing a `settings`<br/>section in the `chart_values` variable. The settings provided here are the ones<br/>mostly likely to be set to other than default values, and are provided here for convenience. | <pre>object({<br/>    batch_idle_duration = optional(string, "1s")<br/>    batch_max_duration  = optional(string, "10s")<br/>  })</pre> | `{}` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -318,6 +318,133 @@ usage: |-
   is recommended. `var.crd_chart_enabled` defaults to `false` to preserve backward compatibility with older versions of
   this component.)
 
+  ## Using Direct EKS Cluster Variables (Recommended)
+
+  This component supports two methods for obtaining EKS cluster information, controlled by the
+  `remote_state_enabled` variable:
+
+  1. **Direct Variables (Recommended)**: Set `remote_state_enabled: false` and pass EKS cluster details directly via input variables
+  2. **Remote State (Default, Deprecated)**: Set `remote_state_enabled: true` (default) to fetch EKS cluster details from Terraform remote state using `eks_component_name`
+
+  ### Direct Variables Approach
+
+  The recommended approach is to provide EKS cluster information directly by setting `remote_state_enabled: false`.
+  This removes the dependency on Cloud Posse's remote state module and gives you more flexibility in how you
+  manage your infrastructure.
+
+  Required variables when `remote_state_enabled` is `false`:
+  - `eks_cluster_id` - The EKS cluster ID (name)
+  - `eks_cluster_arn` - The EKS cluster ARN
+  - `eks_cluster_endpoint` - The EKS cluster API endpoint URL
+  - `eks_cluster_certificate_authority_data` - The base64 encoded certificate data
+  - `eks_cluster_identity_oidc_issuer` - The OIDC Identity issuer for the EKS cluster
+  - `karpenter_node_role_arn` - The ARN of the IAM role for Karpenter nodes
+
+  Example configuration using direct variables:
+
+  ```yaml
+  components:
+    terraform:
+      eks/karpenter:
+        vars:
+          enabled: true
+          name: "karpenter"
+          # Disable remote state and use direct EKS cluster configuration
+          remote_state_enabled: false
+          eks_cluster_id: "my-eks-cluster"
+          eks_cluster_arn: "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster"
+          eks_cluster_endpoint: "https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com"
+          eks_cluster_certificate_authority_data: "LS0tLS1CRUdJTi..."
+          eks_cluster_identity_oidc_issuer: "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
+          karpenter_node_role_arn: "arn:aws:iam::123456789012:role/my-eks-cluster-karpenter-node"
+          # ... other karpenter configuration
+          chart_repository: "oci://public.ecr.aws/karpenter"
+          chart: "karpenter"
+          chart_version: "1.6.0"
+  ```
+
+  You can obtain these values from your EKS cluster's Terraform outputs or via AWS CLI:
+
+  ```bash
+  # Get cluster info
+  aws eks describe-cluster --name my-eks-cluster --query 'cluster.{
+    endpoint: endpoint,
+    arn: arn,
+    certificateAuthority: certificateAuthority.data,
+    oidcIssuer: identity.oidc.issuer
+  }'
+  ```
+
+  ### Migrating from Remote State
+
+  If you're currently using the default `remote_state_enabled: true` with `eks_component_name` to fetch
+  EKS cluster information from remote state, you can migrate to direct variables by:
+
+  1. Get the current values from your EKS cluster's Terraform state or AWS console
+  2. Set `remote_state_enabled: false` in your stack configuration
+  3. Add the direct variable values to your stack configuration
+
+  > [!NOTE]
+  > When `remote_state_enabled` is `false`, all six direct EKS cluster variables are required.
+  > Terraform will fail validation if any are missing.
+
+  ### Using Atmos State Functions (Recommended)
+
+  When using [Atmos](https://atmos.tools), you can use the `!terraform.state` function to read
+  EKS cluster outputs from another component's Terraform state and pass them as variables.
+  This is the recommended approach as it keeps state lookups in your stack configuration
+  rather than in Terraform code.
+
+  ```yaml
+  components:
+    terraform:
+      eks/karpenter:
+        vars:
+          enabled: true
+          name: "karpenter"
+          # Disable internal remote state lookup
+          remote_state_enabled: false
+          # Use Atmos !terraform.state to read values from eks/cluster component
+          eks_cluster_id: !terraform.state eks/cluster eks_cluster_id
+          eks_cluster_arn: !terraform.state eks/cluster eks_cluster_arn
+          eks_cluster_endpoint: !terraform.state eks/cluster eks_cluster_endpoint
+          eks_cluster_certificate_authority_data: !terraform.state eks/cluster eks_cluster_certificate_authority_data
+          eks_cluster_identity_oidc_issuer: !terraform.state eks/cluster eks_cluster_identity_oidc_issuer
+          karpenter_node_role_arn: !terraform.state eks/cluster karpenter_iam_role_arn
+          # ... other karpenter configuration
+          chart_repository: "oci://public.ecr.aws/karpenter"
+          chart: "karpenter"
+          chart_version: "1.6.0"
+  ```
+
+  This approach:
+  - Keeps Terraform code clean without internal remote state dependencies
+  - Uses Atmos native state functions for cross-component references
+  - Works seamlessly with Atmos stack inheritance and overrides
+  - Provides better visibility into component dependencies in stack configuration
+
+  For more information on `!terraform.state`, see the
+  [Atmos documentation](https://atmos.tools/core-concepts/stacks/templating/functions/terraform.state/).
+
+  ### Remote State Approach (Default, Deprecated)
+
+  > [!WARNING]
+  > The `remote_state_enabled: true` setting and `eks_component_name` variable are deprecated and will
+  > be removed in a future version. Please migrate to using direct EKS cluster variables.
+
+  The default (but deprecated) approach uses Cloud Posse's remote state module to fetch EKS cluster information:
+
+  ```yaml
+  components:
+    terraform:
+      eks/karpenter:
+        vars:
+          enabled: true
+          # remote_state_enabled defaults to true (deprecated)
+          eks_component_name: "eks/cluster-blue"
+          # ... other configuration
+  ```
+
   ## Troubleshooting
 
   For Karpenter issues, checkout the [Karpenter Troubleshooting Guide](https://karpenter.sh/docs/troubleshooting/)

--- a/README.yaml
+++ b/README.yaml
@@ -318,82 +318,18 @@ usage: |-
   is recommended. `var.crd_chart_enabled` defaults to `false` to preserve backward compatibility with older versions of
   this component.)
 
-  ## Using Direct EKS Cluster Variables (Recommended)
+  ## EKS Cluster Configuration
 
   This component supports two methods for obtaining EKS cluster information, controlled by the
-  `remote_state_enabled` variable:
+  `account_map_enabled` variable:
 
-  1. **Direct Variables (Recommended)**: Set `remote_state_enabled: false` and pass EKS cluster details directly via input variables
-  2. **Remote State (Default, Deprecated)**: Set `remote_state_enabled: true` (default) to fetch EKS cluster details from Terraform remote state using `eks_component_name`
-
-  ### Direct Variables Approach
-
-  The recommended approach is to provide EKS cluster information directly by setting `remote_state_enabled: false`.
-  This removes the dependency on Cloud Posse's remote state module and gives you more flexibility in how you
-  manage your infrastructure.
-
-  Required variables when `remote_state_enabled` is `false`:
-  - `eks_cluster_id` - The EKS cluster ID (name)
-  - `eks_cluster_arn` - The EKS cluster ARN
-  - `eks_cluster_endpoint` - The EKS cluster API endpoint URL
-  - `eks_cluster_certificate_authority_data` - The base64 encoded certificate data
-  - `eks_cluster_identity_oidc_issuer` - The OIDC Identity issuer for the EKS cluster
-  - `karpenter_node_role_arn` - The ARN of the IAM role for Karpenter nodes
-
-  Example configuration using direct variables:
-
-  ```yaml
-  components:
-    terraform:
-      eks/karpenter:
-        vars:
-          enabled: true
-          name: "karpenter"
-          # Disable remote state and use direct EKS cluster configuration
-          remote_state_enabled: false
-          eks_cluster_id: "my-eks-cluster"
-          eks_cluster_arn: "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster"
-          eks_cluster_endpoint: "https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com"
-          eks_cluster_certificate_authority_data: "LS0tLS1CRUdJTi..."
-          eks_cluster_identity_oidc_issuer: "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
-          karpenter_node_role_arn: "arn:aws:iam::123456789012:role/my-eks-cluster-karpenter-node"
-          # ... other karpenter configuration
-          chart_repository: "oci://public.ecr.aws/karpenter"
-          chart: "karpenter"
-          chart_version: "1.6.0"
-  ```
-
-  You can obtain these values from your EKS cluster's Terraform outputs or via AWS CLI:
-
-  ```bash
-  # Get cluster info
-  aws eks describe-cluster --name my-eks-cluster --query 'cluster.{
-    endpoint: endpoint,
-    arn: arn,
-    certificateAuthority: certificateAuthority.data,
-    oidcIssuer: identity.oidc.issuer
-  }'
-  ```
-
-  ### Migrating from Remote State
-
-  If you're currently using the default `remote_state_enabled: true` with `eks_component_name` to fetch
-  EKS cluster information from remote state, you can migrate to direct variables by:
-
-  1. Get the current values from your EKS cluster's Terraform state or AWS console
-  2. Set `remote_state_enabled: false` in your stack configuration
-  3. Add the direct variable values to your stack configuration
-
-  > [!NOTE]
-  > When `remote_state_enabled` is `false`, all six direct EKS cluster variables are required.
-  > Terraform will fail validation if any are missing.
+  1. **Direct Variables (Recommended)**: Set `account_map_enabled: false` and provide EKS cluster details via the `eks` object variable
+  2. **Internal Remote State (Default)**: Set `account_map_enabled: true` (default) to fetch EKS cluster details from Terraform remote state using `eks_component_name`
 
   ### Using Atmos State Functions (Recommended)
 
   When using [Atmos](https://atmos.tools), you can use the `!terraform.state` function to read
   EKS cluster outputs from another component's Terraform state and pass them as variables.
-  This is the recommended approach as it keeps state lookups in your stack configuration
-  rather than in Terraform code.
 
   ```yaml
   components:
@@ -402,37 +338,25 @@ usage: |-
         vars:
           enabled: true
           name: "karpenter"
-          # Disable internal remote state lookup
-          remote_state_enabled: false
-          # Use Atmos !terraform.state to read values from eks/cluster component
-          eks_cluster_id: !terraform.state eks/cluster eks_cluster_id
-          eks_cluster_arn: !terraform.state eks/cluster eks_cluster_arn
-          eks_cluster_endpoint: !terraform.state eks/cluster eks_cluster_endpoint
-          eks_cluster_certificate_authority_data: !terraform.state eks/cluster eks_cluster_certificate_authority_data
-          eks_cluster_identity_oidc_issuer: !terraform.state eks/cluster eks_cluster_identity_oidc_issuer
-          karpenter_node_role_arn: !terraform.state eks/cluster karpenter_iam_role_arn
-          # ... other karpenter configuration
+          account_map_enabled: false
+          eks:
+            eks_cluster_id: !terraform.state eks/cluster eks_cluster_id
+            eks_cluster_arn: !terraform.state eks/cluster eks_cluster_arn
+            eks_cluster_endpoint: !terraform.state eks/cluster eks_cluster_endpoint
+            eks_cluster_certificate_authority_data: !terraform.state eks/cluster eks_cluster_certificate_authority_data
+            eks_cluster_identity_oidc_issuer: !terraform.state eks/cluster eks_cluster_identity_oidc_issuer
+            karpenter_iam_role_arn: !terraform.state eks/cluster karpenter_iam_role_arn
           chart_repository: "oci://public.ecr.aws/karpenter"
           chart: "karpenter"
           chart_version: "1.6.0"
   ```
 
-  This approach:
-  - Keeps Terraform code clean without internal remote state dependencies
-  - Uses Atmos native state functions for cross-component references
-  - Works seamlessly with Atmos stack inheritance and overrides
-  - Provides better visibility into component dependencies in stack configuration
-
   For more information on `!terraform.state`, see the
   [Atmos documentation](https://atmos.tools/core-concepts/stacks/templating/functions/terraform.state/).
 
-  ### Remote State Approach (Default, Deprecated)
+  ### Direct Variables Approach
 
-  > [!WARNING]
-  > The `remote_state_enabled: true` setting and `eks_component_name` variable are deprecated and will
-  > be removed in a future version. Please migrate to using direct EKS cluster variables.
-
-  The default (but deprecated) approach uses Cloud Posse's remote state module to fetch EKS cluster information:
+  You can also provide EKS cluster information directly:
 
   ```yaml
   components:
@@ -440,9 +364,32 @@ usage: |-
       eks/karpenter:
         vars:
           enabled: true
-          # remote_state_enabled defaults to true (deprecated)
+          name: "karpenter"
+          account_map_enabled: false
+          eks:
+            eks_cluster_id: "my-eks-cluster"
+            eks_cluster_arn: "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster"
+            eks_cluster_endpoint: "https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com"
+            eks_cluster_certificate_authority_data: "LS0tLS1CRUdJTi..."
+            eks_cluster_identity_oidc_issuer: "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
+            karpenter_iam_role_arn: "arn:aws:iam::123456789012:role/my-eks-cluster-karpenter-node"
+          chart_repository: "oci://public.ecr.aws/karpenter"
+          chart: "karpenter"
+          chart_version: "1.6.0"
+  ```
+
+  ### Internal Remote State Approach (Default)
+
+  The default approach uses Cloud Posse's remote state module to fetch EKS cluster information:
+
+  ```yaml
+  components:
+    terraform:
+      eks/karpenter:
+        vars:
+          enabled: true
+          # account_map_enabled defaults to true
           eks_component_name: "eks/cluster-blue"
-          # ... other configuration
   ```
 
   ## Troubleshooting

--- a/src/main.tf
+++ b/src/main.tf
@@ -8,11 +8,13 @@ locals {
   aws_partition = coalesce(one(data.aws_partition.current[*].partition), "aws")
 
   # eks_cluster_id is defined in provider-helm.tf
-  # eks_cluster_id = module.eks.outputs.eks_cluster_id
-  eks_cluster_arn                  = module.eks.outputs.eks_cluster_arn
-  eks_cluster_identity_oidc_issuer = module.eks.outputs.eks_cluster_identity_oidc_issuer
+  # When remote_state_enabled is false, direct variables are required (enforced by validation)
+  # When remote_state_enabled is true, values come from remote state
+  eks_cluster_arn = local.remote_state_enabled ? module.eks.outputs.eks_cluster_arn : var.eks_cluster_arn
 
-  karpenter_node_role_arn = module.eks.outputs.karpenter_iam_role_arn
+  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks.outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
+
+  karpenter_node_role_arn = local.remote_state_enabled ? module.eks.outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
 
   # Prior to Karpenter v0.32.0 (the v1Alpha APIs), Karpenter recommended using a dedicated namespace for Karpenter resources.
   # Starting with Karpenter v0.32.0, Karpenter recommends installing Karpenter resources in the kube-system namespace.

--- a/src/main.tf
+++ b/src/main.tf
@@ -8,13 +8,10 @@ locals {
   aws_partition = coalesce(one(data.aws_partition.current[*].partition), "aws")
 
   # eks_cluster_id is defined in provider-helm.tf
-  # When remote_state_enabled is false, direct variables are required (enforced by validation)
-  # When remote_state_enabled is true, values come from remote state
-  eks_cluster_arn = local.remote_state_enabled ? module.eks.outputs.eks_cluster_arn : var.eks_cluster_arn
-
-  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks.outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
-
-  karpenter_node_role_arn = local.remote_state_enabled ? module.eks.outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
+  # EKS values come from module.eks.outputs - when bypassed, returns defaults (direct variables)
+  eks_cluster_arn                  = module.eks.outputs.eks_cluster_arn
+  eks_cluster_identity_oidc_issuer = module.eks.outputs.eks_cluster_identity_oidc_issuer
+  karpenter_node_role_arn          = module.eks.outputs.karpenter_iam_role_arn
 
   # Prior to Karpenter v0.32.0 (the v1Alpha APIs), Karpenter recommended using a dedicated namespace for Karpenter resources.
   # Starting with Karpenter v0.32.0, Karpenter recommends installing Karpenter resources in the kube-system namespace.

--- a/src/main.tf
+++ b/src/main.tf
@@ -10,11 +10,11 @@ locals {
   # eks_cluster_id is defined in provider-helm.tf
   # When remote_state_enabled is false, direct variables are required (enforced by validation)
   # When remote_state_enabled is true, values come from remote state
-  eks_cluster_arn = local.remote_state_enabled ? module.eks.outputs.eks_cluster_arn : var.eks_cluster_arn
+  eks_cluster_arn = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_arn : var.eks_cluster_arn
 
-  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks.outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
+  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
 
-  karpenter_node_role_arn = local.remote_state_enabled ? module.eks.outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
+  karpenter_node_role_arn = local.remote_state_enabled ? module.eks[0].outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
 
   # Prior to Karpenter v0.32.0 (the v1Alpha APIs), Karpenter recommended using a dedicated namespace for Karpenter resources.
   # Starting with Karpenter v0.32.0, Karpenter recommends installing Karpenter resources in the kube-system namespace.

--- a/src/main.tf
+++ b/src/main.tf
@@ -10,11 +10,11 @@ locals {
   # eks_cluster_id is defined in provider-helm.tf
   # When remote_state_enabled is false, direct variables are required (enforced by validation)
   # When remote_state_enabled is true, values come from remote state
-  eks_cluster_arn = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_arn : var.eks_cluster_arn
+  eks_cluster_arn = local.remote_state_enabled ? module.eks.outputs.eks_cluster_arn : var.eks_cluster_arn
 
-  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
+  eks_cluster_identity_oidc_issuer = local.remote_state_enabled ? module.eks.outputs.eks_cluster_identity_oidc_issuer : var.eks_cluster_identity_oidc_issuer
 
-  karpenter_node_role_arn = local.remote_state_enabled ? module.eks[0].outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
+  karpenter_node_role_arn = local.remote_state_enabled ? module.eks.outputs.karpenter_iam_role_arn : var.karpenter_node_role_arn
 
   # Prior to Karpenter v0.32.0 (the v1Alpha APIs), Karpenter recommended using a dedicated namespace for Karpenter resources.
   # Starting with Karpenter v0.32.0, Karpenter recommends installing Karpenter resources in the kube-system namespace.

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -138,18 +138,11 @@ locals {
     "--role-arn", local.kube_exec_auth_role_arn
   ] : []
 
-  # When remote_state_enabled is false, direct variables are required (enforced by validation)
-  # When remote_state_enabled is true, values come from remote state
-  certificate_authority_data = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks.outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
-  )
-  cluster_ca_certificate = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
-
-  eks_cluster_id = local.remote_state_enabled ? module.eks.outputs.eks_cluster_id : var.eks_cluster_id
-
-  eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks.outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
-  )
+  # EKS values come from module.eks.outputs - when bypassed, returns defaults (direct variables)
+  certificate_authority_data = local.kubeconfig_file_enabled ? null : module.eks.outputs.eks_cluster_certificate_authority_data
+  cluster_ca_certificate     = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
+  eks_cluster_id             = module.eks.outputs.eks_cluster_id
+  eks_cluster_endpoint       = local.kubeconfig_file_enabled ? null : module.eks.outputs.eks_cluster_endpoint
 }
 
 data "aws_eks_cluster_auth" "eks" {

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -141,14 +141,14 @@ locals {
   # When remote_state_enabled is false, direct variables are required (enforced by validation)
   # When remote_state_enabled is true, values come from remote state
   certificate_authority_data = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks.outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
+    local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
   )
   cluster_ca_certificate = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
 
-  eks_cluster_id = local.remote_state_enabled ? module.eks.outputs.eks_cluster_id : var.eks_cluster_id
+  eks_cluster_id = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_id : var.eks_cluster_id
 
   eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks.outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
+    local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
   )
 }
 

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -138,12 +138,18 @@ locals {
     "--role-arn", local.kube_exec_auth_role_arn
   ] : []
 
-  # Provide dummy configuration for the case where the EKS cluster is not available.
-  certificate_authority_data = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_certificate_authority_data, null)
-  cluster_ca_certificate     = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
-  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
-  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
-  eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_endpoint, "")
+  # When remote_state_enabled is false, direct variables are required (enforced by validation)
+  # When remote_state_enabled is true, values come from remote state
+  certificate_authority_data = local.kubeconfig_file_enabled ? null : (
+    local.remote_state_enabled ? module.eks.outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
+  )
+  cluster_ca_certificate = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
+
+  eks_cluster_id = local.remote_state_enabled ? module.eks.outputs.eks_cluster_id : var.eks_cluster_id
+
+  eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : (
+    local.remote_state_enabled ? module.eks.outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
+  )
 }
 
 data "aws_eks_cluster_auth" "eks" {

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -141,14 +141,14 @@ locals {
   # When remote_state_enabled is false, direct variables are required (enforced by validation)
   # When remote_state_enabled is true, values come from remote state
   certificate_authority_data = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
+    local.remote_state_enabled ? module.eks.outputs.eks_cluster_certificate_authority_data : var.eks_cluster_certificate_authority_data
   )
   cluster_ca_certificate = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
 
-  eks_cluster_id = local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_id : var.eks_cluster_id
+  eks_cluster_id = local.remote_state_enabled ? module.eks.outputs.eks_cluster_id : var.eks_cluster_id
 
   eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : (
-    local.remote_state_enabled ? module.eks[0].outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
+    local.remote_state_enabled ? module.eks.outputs.eks_cluster_endpoint : var.eks_cluster_endpoint
   )
 }
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -37,7 +37,9 @@ module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  count = local.remote_state_enabled ? 1 : 0
+  # When bypass is true, skip remote state lookup and return defaults
+  # We bypass when remote_state_enabled is false (using direct variables instead)
+  bypass = !local.remote_state_enabled
 
   component = var.eks_component_name
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,43 @@
+locals {
+  # Remote state is enabled when var.remote_state_enabled is true and the module is enabled
+  remote_state_enabled = local.enabled && var.remote_state_enabled
+
+  # Validation: when remote_state_enabled is false, all direct EKS cluster variables must be provided
+  _validate_direct_vars = !var.remote_state_enabled ? (
+    var.eks_cluster_id != null &&
+    var.eks_cluster_arn != null &&
+    var.eks_cluster_endpoint != null &&
+    var.eks_cluster_certificate_authority_data != null &&
+    var.eks_cluster_identity_oidc_issuer != null &&
+    var.karpenter_node_role_arn != null
+  ) : true
+}
+
+# Validation resource to ensure proper configuration
+resource "terraform_data" "validate_eks_config" {
+  count = local.enabled ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = local._validate_direct_vars
+      error_message = <<-EOT
+      When remote_state_enabled is false, all direct EKS cluster variables must be provided:
+        - eks_cluster_id
+        - eks_cluster_arn
+        - eks_cluster_endpoint
+        - eks_cluster_certificate_authority_data
+        - eks_cluster_identity_oidc_issuer
+        - karpenter_node_role_arn
+      EOT
+    }
+  }
+}
+
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
+
+  enabled = local.remote_state_enabled
 
   component = var.eks_component_name
 
@@ -8,9 +45,11 @@ module "eks" {
 
   # Attempt to allow this component to be deleted from Terraform state even after the EKS cluster has been deleted
   defaults = {
-    eks_cluster_id                   = "deleted"
-    eks_cluster_arn                  = "deleted"
-    eks_cluster_identity_oidc_issuer = "deleted"
-    karpenter_node_role_arn          = "deleted"
+    eks_cluster_id                         = "deleted"
+    eks_cluster_arn                        = "deleted"
+    eks_cluster_endpoint                   = "deleted"
+    eks_cluster_certificate_authority_data = ""
+    eks_cluster_identity_oidc_issuer       = "deleted"
+    karpenter_iam_role_arn                 = "deleted"
   }
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -37,7 +37,7 @@ module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  enabled = local.remote_state_enabled
+  count = local.remote_state_enabled ? 1 : 0
 
   component = var.eks_component_name
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,58 +1,23 @@
 locals {
-  # Remote state is enabled when var.remote_state_enabled is true and the module is enabled
-  remote_state_enabled = local.enabled && var.remote_state_enabled
-
-  # Validation: when remote_state_enabled is false, all direct EKS cluster variables must be provided
-  _validate_direct_vars = !var.remote_state_enabled ? (
-    var.eks_cluster_id != null &&
-    var.eks_cluster_arn != null &&
-    var.eks_cluster_endpoint != null &&
-    var.eks_cluster_certificate_authority_data != null &&
-    var.eks_cluster_identity_oidc_issuer != null &&
-    var.karpenter_node_role_arn != null
-  ) : true
-}
-
-# Validation resource to ensure proper configuration
-resource "terraform_data" "validate_eks_config" {
-  count = local.enabled ? 1 : 0
-
-  lifecycle {
-    precondition {
-      condition     = local._validate_direct_vars
-      error_message = <<-EOT
-      When remote_state_enabled is false, all direct EKS cluster variables must be provided:
-        - eks_cluster_id
-        - eks_cluster_arn
-        - eks_cluster_endpoint
-        - eks_cluster_certificate_authority_data
-        - eks_cluster_identity_oidc_issuer
-        - karpenter_node_role_arn
-      EOT
-    }
-  }
+  account_map_enabled = local.enabled && var.account_map_enabled
 }
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  # When bypass is true, skip remote state lookup and return defaults
-  # We bypass when remote_state_enabled is false (using direct variables instead)
-  bypass = !local.remote_state_enabled
+  bypass = !local.account_map_enabled
 
   component = var.eks_component_name
 
   context = module.this.context
 
-  # When bypassed, use direct variables as defaults
-  # When not bypassed but remote state is missing, fall back to "deleted" for graceful degradation
   defaults = {
-    eks_cluster_id                         = coalesce(var.eks_cluster_id, "deleted")
-    eks_cluster_arn                        = coalesce(var.eks_cluster_arn, "deleted")
-    eks_cluster_endpoint                   = coalesce(var.eks_cluster_endpoint, "deleted")
-    eks_cluster_certificate_authority_data = coalesce(var.eks_cluster_certificate_authority_data, "")
-    eks_cluster_identity_oidc_issuer       = coalesce(var.eks_cluster_identity_oidc_issuer, "deleted")
-    karpenter_iam_role_arn                 = coalesce(var.karpenter_node_role_arn, "deleted")
+    eks_cluster_id                         = coalesce(var.eks.eks_cluster_id, "deleted")
+    eks_cluster_arn                        = coalesce(var.eks.eks_cluster_arn, "deleted")
+    eks_cluster_endpoint                   = coalesce(var.eks.eks_cluster_endpoint, "deleted")
+    eks_cluster_certificate_authority_data = coalesce(var.eks.eks_cluster_certificate_authority_data, "")
+    eks_cluster_identity_oidc_issuer       = coalesce(var.eks.eks_cluster_identity_oidc_issuer, "deleted")
+    karpenter_iam_role_arn                 = coalesce(var.eks.karpenter_iam_role_arn, "deleted")
   }
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -45,13 +45,14 @@ module "eks" {
 
   context = module.this.context
 
-  # Attempt to allow this component to be deleted from Terraform state even after the EKS cluster has been deleted
+  # When bypassed, use direct variables as defaults
+  # When not bypassed but remote state is missing, fall back to "deleted" for graceful degradation
   defaults = {
-    eks_cluster_id                         = "deleted"
-    eks_cluster_arn                        = "deleted"
-    eks_cluster_endpoint                   = "deleted"
-    eks_cluster_certificate_authority_data = ""
-    eks_cluster_identity_oidc_issuer       = "deleted"
-    karpenter_iam_role_arn                 = "deleted"
+    eks_cluster_id                         = coalesce(var.eks_cluster_id, "deleted")
+    eks_cluster_arn                        = coalesce(var.eks_cluster_arn, "deleted")
+    eks_cluster_endpoint                   = coalesce(var.eks_cluster_endpoint, "deleted")
+    eks_cluster_certificate_authority_data = coalesce(var.eks_cluster_certificate_authority_data, "")
+    eks_cluster_identity_oidc_issuer       = coalesce(var.eks_cluster_identity_oidc_issuer, "deleted")
+    karpenter_iam_role_arn                 = coalesce(var.karpenter_node_role_arn, "deleted")
   }
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -16,7 +16,7 @@ module "eks" {
     eks_cluster_id                         = coalesce(var.eks.eks_cluster_id, "deleted")
     eks_cluster_arn                        = coalesce(var.eks.eks_cluster_arn, "deleted")
     eks_cluster_endpoint                   = coalesce(var.eks.eks_cluster_endpoint, "deleted")
-    eks_cluster_certificate_authority_data = coalesce(var.eks.eks_cluster_certificate_authority_data, "")
+    eks_cluster_certificate_authority_data = var.eks.eks_cluster_certificate_authority_data
     eks_cluster_identity_oidc_issuer       = coalesce(var.eks.eks_cluster_identity_oidc_issuer, "deleted")
     karpenter_iam_role_arn                 = coalesce(var.eks.karpenter_iam_role_arn, "deleted")
   }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -81,71 +81,29 @@ variable "chart_values" {
   default     = {}
 }
 
-variable "remote_state_enabled" {
+variable "account_map_enabled" {
   type        = bool
-  description = <<-EOT
-  If `true`, fetch EKS cluster information from Terraform remote state using `eks_component_name`.
-  If `false`, use direct EKS cluster input variables instead.
-
-  When set to `false`, the following variables are required:
-  - var.eks_cluster_id
-  - var.eks_cluster_arn
-  - var.eks_cluster_endpoint
-  - var.eks_cluster_certificate_authority_data
-  - var.eks_cluster_identity_oidc_issuer
-  - var.karpenter_node_role_arn
-  EOT
+  description = "Enable the account map component lookup. When disabled, use the `eks` variable to provide static EKS cluster configuration."
   default     = true
-  nullable    = false
 }
 
 variable "eks_component_name" {
   type        = string
-  description = <<-EOT
-  The name of the eks component. Used to fetch EKS cluster information from remote state
-  when `remote_state_enabled` is `true`.
-
-  DEPRECATED: This variable (along with remote_state_enabled=true) is deprecated and
-  will be removed in a future version. Set `remote_state_enabled = false` and use
-  the direct EKS cluster input variables instead.
-  EOT
+  description = "The name of the eks component. Used when `account_map_enabled` is `true`."
   default     = "eks/cluster"
 }
 
-variable "eks_cluster_id" {
-  type        = string
-  description = "The EKS cluster ID (name). Required when `remote_state_enabled` is `false`."
-  default     = null
-}
-
-variable "eks_cluster_arn" {
-  type        = string
-  description = "The EKS cluster ARN. Required when `remote_state_enabled` is `false`."
-  default     = null
-}
-
-variable "eks_cluster_endpoint" {
-  type        = string
-  description = "The EKS cluster endpoint URL. Required when `remote_state_enabled` is `false`."
-  default     = null
-}
-
-variable "eks_cluster_certificate_authority_data" {
-  type        = string
-  description = "The base64 encoded certificate data required to communicate with the EKS cluster. Required when `remote_state_enabled` is `false`."
-  default     = null
-}
-
-variable "eks_cluster_identity_oidc_issuer" {
-  type        = string
-  description = "The OIDC Identity issuer for the EKS cluster. Required when `remote_state_enabled` is `false`."
-  default     = null
-}
-
-variable "karpenter_node_role_arn" {
-  type        = string
-  description = "The ARN of the IAM role for Karpenter nodes. Required when `remote_state_enabled` is `false`."
-  default     = null
+variable "eks" {
+  type = object({
+    eks_cluster_id                         = optional(string, "")
+    eks_cluster_arn                        = optional(string, "")
+    eks_cluster_endpoint                   = optional(string, "")
+    eks_cluster_certificate_authority_data = optional(string, "")
+    eks_cluster_identity_oidc_issuer       = optional(string, "")
+    karpenter_iam_role_arn                 = optional(string, "")
+  })
+  description = "EKS cluster configuration. Required when `account_map_enabled` is `false`."
+  default     = {}
 }
 
 variable "metrics_enabled" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -81,10 +81,71 @@ variable "chart_values" {
   default     = {}
 }
 
+variable "remote_state_enabled" {
+  type        = bool
+  description = <<-EOT
+  If `true`, fetch EKS cluster information from Terraform remote state using `eks_component_name`.
+  If `false`, use direct EKS cluster input variables instead.
+
+  When set to `false`, the following variables are required:
+  - var.eks_cluster_id
+  - var.eks_cluster_arn
+  - var.eks_cluster_endpoint
+  - var.eks_cluster_certificate_authority_data
+  - var.eks_cluster_identity_oidc_issuer
+  - var.karpenter_node_role_arn
+  EOT
+  default     = true
+  nullable    = false
+}
+
 variable "eks_component_name" {
   type        = string
-  description = "The name of the eks component"
+  description = <<-EOT
+  The name of the eks component. Used to fetch EKS cluster information from remote state
+  when `remote_state_enabled` is `true`.
+
+  DEPRECATED: This variable (along with remote_state_enabled=true) is deprecated and
+  will be removed in a future version. Set `remote_state_enabled = false` and use
+  the direct EKS cluster input variables instead.
+  EOT
   default     = "eks/cluster"
+}
+
+variable "eks_cluster_id" {
+  type        = string
+  description = "The EKS cluster ID (name). Required when `remote_state_enabled` is `false`."
+  default     = null
+}
+
+variable "eks_cluster_arn" {
+  type        = string
+  description = "The EKS cluster ARN. Required when `remote_state_enabled` is `false`."
+  default     = null
+}
+
+variable "eks_cluster_endpoint" {
+  type        = string
+  description = "The EKS cluster endpoint URL. Required when `remote_state_enabled` is `false`."
+  default     = null
+}
+
+variable "eks_cluster_certificate_authority_data" {
+  type        = string
+  description = "The base64 encoded certificate data required to communicate with the EKS cluster. Required when `remote_state_enabled` is `false`."
+  default     = null
+}
+
+variable "eks_cluster_identity_oidc_issuer" {
+  type        = string
+  description = "The OIDC Identity issuer for the EKS cluster. Required when `remote_state_enabled` is `false`."
+  default     = null
+}
+
+variable "karpenter_node_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role for Karpenter nodes. Required when `remote_state_enabled` is `false`."
+  default     = null
 }
 
 variable "metrics_enabled" {


### PR DESCRIPTION
## Summary

- Add `account_map_enabled` variable to control whether to use remote state or direct variables
- Add `eks` object variable to provide EKS cluster configuration directly (as an alternative to remote state lookup)
- Update remote-state module to use `bypass` pattern with defaults from `var.eks`
- Simplify EKS value references in `main.tf` and `provider-helm.tf` by using module outputs directly
- Add documentation with examples for Atmos `!terraform.state` and direct variable approaches

## Changes

### New Variables

- `account_map_enabled` (bool, default: `true`) - When `false`, uses the `eks` object variable instead of remote state
- `eks` (object) - EKS cluster configuration object with fields:
  - `eks_cluster_id`
  - `eks_cluster_arn`
  - `eks_cluster_endpoint`
  - `eks_cluster_certificate_authority_data`
  - `eks_cluster_identity_oidc_issuer`
  - `karpenter_iam_role_arn`

### Usage

```yaml
components:
  terraform:
    eks/karpenter:
      vars:
        account_map_enabled: false
        eks:
          eks_cluster_id: !terraform.state eks/cluster eks_cluster_id
          eks_cluster_arn: !terraform.state eks/cluster eks_cluster_arn
          eks_cluster_endpoint: !terraform.state eks/cluster eks_cluster_endpoint
          eks_cluster_certificate_authority_data: !terraform.state eks/cluster eks_cluster_certificate_authority_data
          eks_cluster_identity_oidc_issuer: !terraform.state eks/cluster eks_cluster_identity_oidc_issuer
          karpenter_iam_role_arn: !terraform.state eks/cluster karpenter_iam_role_arn
```

## Test plan

- [ ] Verify backward compatibility with `account_map_enabled: true` (default)
- [ ] Test with `account_map_enabled: false` and direct `eks` object values
- [ ] Verify Atmos `!terraform.state` approach works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EKS Cluster Configuration guide describing two configuration methods: Direct Variables and Internal Remote State approaches with usage examples.
  * Added guidance on using Atmos State Functions for reading EKS outputs.

* **New Features**
  * Added `account_map_enabled` option to toggle between static EKS configuration or remote state lookup.
  * Added `eks` input for specifying EKS cluster details when using the direct variable approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->