### PR TITLE
feat: gate Karpenter controller on EKS Auto Mode

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -2,7 +2,7 @@
 # https://karpenter.sh/
 
 locals {
-  enabled = module.this.enabled
+  enabled = module.this.enabled && !var.eks_auto_mode_enabled
 
   # We need aws_partition to be non-null even when this module is disabled, because it is used in a string template
   aws_partition = coalesce(one(data.aws_partition.current[*].partition), "aws")

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -3,6 +3,13 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "eks_auto_mode_enabled" {
+  type        = bool
+  description = "Set to true if the EKS cluster has Auto Mode compute enabled. When true, this component is disabled because Auto Mode includes managed Karpenter, making a self-managed Karpenter deployment unnecessary."
+  default     = false
+  nullable    = false
+}
+
 variable "chart_description" {
   type        = string
   description = "Set release description attribute (visible in the history)"


### PR DESCRIPTION
## Summary
- Add `eks_auto_mode_enabled` variable (bool, default `false`)
- Gate all resources via `local.enabled = module.this.enabled && !var.eks_auto_mode_enabled`
- When Auto Mode compute is enabled, AWS manages Karpenter, making self-managed deployment unnecessary

## Test plan
- [ ] `terraform plan` with `eks_auto_mode_enabled = false` shows no changes (backward compat)
- [ ] `terraform plan` with `eks_auto_mode_enabled = true` shows all resources destroyed/not created
- [ ] Verify helm release, IAM role, SQS queue, and EventBridge rules are all gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)